### PR TITLE
develop/addNavigation

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "com.google.android.material:material:1.6.1"
     implementation "androidx.preference:preference-ktx:1.2.0"
+    implementation 'androidx.appcompat:appcompat:1.5.0'
 
     // Room components
     def roomVersion = "2.4.2"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,15 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.APIPracticeApp"
-        tools:targetApi="31" />
+        tools:targetApi="31">
+        <activity
+            android:name=".ui.MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/example/apipracticeapp/ui/ResultFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/ResultFragment.kt
@@ -5,15 +5,14 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.example.apipracticeapp.R
+import com.example.apipracticeapp.databinding.FragmentResultBinding
 
 class ResultFragment : Fragment() {
-
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_result, container, false)
+    ): View {
+        val binding = FragmentResultBinding.inflate(inflater, container, false)
+        return binding.root
     }
 }

--- a/app/src/main/java/com/example/apipracticeapp/ui/ResultFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/ResultFragment.kt
@@ -8,11 +8,21 @@ import android.view.ViewGroup
 import com.example.apipracticeapp.databinding.FragmentResultBinding
 
 class ResultFragment : Fragment() {
+    private var _binding: FragmentResultBinding? = null
+    private val binding get() = _binding!!
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = FragmentResultBinding.inflate(inflater, container, false)
+        _binding = FragmentResultBinding.inflate(inflater, container, false)
+
         return binding.root
+    }
+
+    //bindingの解放
+    override fun onDestroyView() {
+        super.onDestroyView()
+        //bindingの解放
+        _binding = null
     }
 }

--- a/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
@@ -38,7 +38,7 @@ class SearchFragment : Fragment() {
         _binding = null
     }
 
-    fun navigationResultFragment() {
+    private fun navigationResultFragment() {
         findNavController().navigate(R.id.resultFragment)
     }
 }

--- a/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
@@ -5,14 +5,14 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import com.example.apipracticeapp.R
+import com.example.apipracticeapp.databinding.FragmentSearchBinding
 
 class SearchFragment : Fragment() {
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_search, container, false)
+    ): View {
+        val binding = FragmentSearchBinding.inflate(inflater, container, false)
+        return binding.root
     }
 }

--- a/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
@@ -20,12 +20,8 @@ class SearchFragment : Fragment() {
     ): View {
         _binding = FragmentSearchBinding.inflate(inflater, container, false)
 
-        binding.searchEditText.setOnEditorActionListener { textView, actionId, keyEvent ->
-            if (actionId == EditorInfo.IME_ACTION_SEARCH || actionId == EditorInfo.IME_NULL) {
+        binding.reloadButton.setOnClickListener {
                 navigationResultFragment()
-                return@setOnEditorActionListener true
-            }
-            return@setOnEditorActionListener false
         }
 
         return binding.root

--- a/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
@@ -5,6 +5,9 @@ import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import androidx.navigation.fragment.findNavController
+import com.example.apipracticeapp.R
 import com.example.apipracticeapp.databinding.FragmentSearchBinding
 
 class SearchFragment : Fragment() {
@@ -16,6 +19,15 @@ class SearchFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
         _binding = FragmentSearchBinding.inflate(inflater, container, false)
+
+        binding.searchEditText.setOnEditorActionListener { textView, actionId, keyEvent ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH || actionId == EditorInfo.IME_NULL) {
+                navigationResultFragment()
+                return@setOnEditorActionListener true
+            }
+            return@setOnEditorActionListener false
+        }
+
         return binding.root
     }
 
@@ -24,5 +36,9 @@ class SearchFragment : Fragment() {
         super.onDestroyView()
         //bindingの解放
         _binding = null
+    }
+
+    fun navigationResultFragment() {
+        findNavController().navigate(R.id.resultFragment)
     }
 }

--- a/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/SearchFragment.kt
@@ -8,11 +8,21 @@ import android.view.ViewGroup
 import com.example.apipracticeapp.databinding.FragmentSearchBinding
 
 class SearchFragment : Fragment() {
+    private var _binding: FragmentSearchBinding? = null
+    private val binding get() = _binding!!
+
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val binding = FragmentSearchBinding.inflate(inflater, container, false)
+        _binding = FragmentSearchBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    //bindingの解放
+    override fun onDestroyView() {
+        super.onDestroyView()
+        //bindingの解放
+        _binding = null
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,4 +6,15 @@
     android:layout_height="match_parent"
     tools:context=".ui.MainActivity">
 
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainerView2"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/nav_graph" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_result.xml
+++ b/app/src/main/res/layout/fragment_result.xml
@@ -1,173 +1,180 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.ResultFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <data>
+
+    </data>
+
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.ResultFragment">
 
-        <ImageView
-            android:id="@+id/imageView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toTopOf="@id/repository_name_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            tools:src="@tools:sample/avatars"
-            android:contentDescription="@string/repository_photo" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
 
-        <TextView
-            android:id="@+id/repository_name_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="TextView"
-            app:layout_constraintBottom_toTopOf="@id/language_left_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/imageView" />
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toTopOf="@id/repository_name_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:src="@tools:sample/avatars"
+                android:contentDescription="@string/repository_photo" />
 
-        <TextView
-            android:id="@+id/language_left_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:text="@string/language"
-            app:layout_constraintBottom_toTopOf="@id/stars_left_text"
-            app:layout_constraintEnd_toStartOf="@id/language_right_text"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/repository_name_text" />
+            <TextView
+                android:id="@+id/repository_name_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="TextView"
+                app:layout_constraintBottom_toTopOf="@id/language_left_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/imageView" />
 
-        <TextView
-            android:id="@+id/language_right_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="TextView"
-            app:layout_constraintBottom_toBottomOf="@id/language_left_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/language_left_text"
-            app:layout_constraintTop_toTopOf="@id/language_left_text" />
+            <TextView
+                android:id="@+id/language_left_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/language"
+                app:layout_constraintBottom_toTopOf="@id/stars_left_text"
+                app:layout_constraintEnd_toStartOf="@id/language_right_text"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/repository_name_text" />
 
-        <TextView
-            android:id="@+id/stars_left_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:text="@string/stars"
-            app:layout_constraintBottom_toTopOf="@id/watchers_left_text"
-            app:layout_constraintEnd_toStartOf="@id/stars_right_text"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/language_left_text" />
+            <TextView
+                android:id="@+id/language_right_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="TextView"
+                app:layout_constraintBottom_toBottomOf="@id/language_left_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/language_left_text"
+                app:layout_constraintTop_toTopOf="@id/language_left_text" />
 
-        <TextView
-            android:id="@+id/stars_right_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="TextView"
-            app:layout_constraintBottom_toBottomOf="@id/stars_left_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/stars_left_text"
-            app:layout_constraintTop_toTopOf="@id/stars_left_text" />
+            <TextView
+                android:id="@+id/stars_left_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/stars"
+                app:layout_constraintBottom_toTopOf="@id/watchers_left_text"
+                app:layout_constraintEnd_toStartOf="@id/stars_right_text"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/language_left_text" />
 
-        <TextView
-            android:id="@+id/watchers_left_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:text="@string/watchers"
-            app:layout_constraintBottom_toTopOf="@id/fork_left_text"
-            app:layout_constraintEnd_toStartOf="@id/watchers_right_text"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/stars_left_text" />
+            <TextView
+                android:id="@+id/stars_right_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="TextView"
+                app:layout_constraintBottom_toBottomOf="@id/stars_left_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/stars_left_text"
+                app:layout_constraintTop_toTopOf="@id/stars_left_text" />
 
-        <TextView
-            android:id="@+id/watchers_right_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="TextView"
-            app:layout_constraintBottom_toBottomOf="@id/watchers_left_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/watchers_left_text"
-            app:layout_constraintTop_toTopOf="@id/watchers_left_text" />
+            <TextView
+                android:id="@+id/watchers_left_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/watchers"
+                app:layout_constraintBottom_toTopOf="@id/fork_left_text"
+                app:layout_constraintEnd_toStartOf="@id/watchers_right_text"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/stars_left_text" />
 
-        <TextView
-            android:id="@+id/fork_left_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:text="@string/fork_number"
-            app:layout_constraintBottom_toTopOf="@id/issue_left_text"
-            app:layout_constraintEnd_toStartOf="@id/fork_right_text"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/watchers_left_text" />
+            <TextView
+                android:id="@+id/watchers_right_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="TextView"
+                app:layout_constraintBottom_toBottomOf="@id/watchers_left_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/watchers_left_text"
+                app:layout_constraintTop_toTopOf="@id/watchers_left_text" />
 
-        <TextView
-            android:id="@+id/fork_right_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="TextView"
-            app:layout_constraintBottom_toBottomOf="@id/fork_left_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/fork_left_text"
-            app:layout_constraintTop_toTopOf="@id/fork_left_text" />
+            <TextView
+                android:id="@+id/fork_left_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/fork_number"
+                app:layout_constraintBottom_toTopOf="@id/issue_left_text"
+                app:layout_constraintEnd_toStartOf="@id/fork_right_text"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/watchers_left_text" />
 
-        <TextView
-            android:id="@+id/issue_left_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:text="@string/issue_number"
-            app:layout_constraintBottom_toTopOf="@id/writer_left_name"
-            app:layout_constraintEnd_toStartOf="@id/issue_right_text"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/fork_left_text" />
+            <TextView
+                android:id="@+id/fork_right_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="TextView"
+                app:layout_constraintBottom_toBottomOf="@id/fork_left_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/fork_left_text"
+                app:layout_constraintTop_toTopOf="@id/fork_left_text" />
 
-        <TextView
-            android:id="@+id/issue_right_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="TextView"
-            app:layout_constraintBottom_toBottomOf="@id/issue_left_text"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/issue_left_text"
-            app:layout_constraintTop_toTopOf="@id/issue_left_text" />
+            <TextView
+                android:id="@+id/issue_left_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/issue_number"
+                app:layout_constraintBottom_toTopOf="@id/writer_left_name"
+                app:layout_constraintEnd_toStartOf="@id/issue_right_text"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/fork_left_text" />
 
-        <TextView
-            android:id="@+id/writer_left_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="16dp"
-            android:text="@string/writer_name"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/writer_right_name"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/issue_left_text" />
+            <TextView
+                android:id="@+id/issue_right_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="TextView"
+                app:layout_constraintBottom_toBottomOf="@id/issue_left_text"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/issue_left_text"
+                app:layout_constraintTop_toTopOf="@id/issue_left_text" />
 
-        <TextView
-            android:id="@+id/writer_right_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:text="TextView"
-            app:layout_constraintBottom_toBottomOf="@id/writer_left_name"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/writer_left_name"
-            app:layout_constraintTop_toTopOf="@id/writer_left_name" />
+            <TextView
+                android:id="@+id/writer_left_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:text="@string/writer_name"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/writer_right_name"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/issue_left_text" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</FrameLayout>
+            <TextView
+                android:id="@+id/writer_right_name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:text="TextView"
+                app:layout_constraintBottom_toBottomOf="@id/writer_left_name"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/writer_left_name"
+                app:layout_constraintTop_toTopOf="@id/writer_left_name" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -17,7 +17,7 @@
             android:layout_height="match_parent">
 
             <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/textInputLayout2"
+                android:id="@+id/search_input_text"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:layout_constraintEnd_toEndOf="parent"
@@ -25,9 +25,12 @@
                 app:layout_constraintTop_toTopOf="parent">
 
                 <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/search_edit_text"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:hint="@string/hint_text" />
+                    android:hint="@string/hint_text"
+                    android:imeOptions="actionSearch"
+                    android:maxLines="1" />
 
             </com.google.android.material.textfield.TextInputLayout>
 
@@ -37,7 +40,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/textInputLayout2">
+                app:layout_constraintTop_toBottomOf="@id/search_input_text">
 
             </androidx.recyclerview.widget.RecyclerView>
 
@@ -49,7 +52,7 @@
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/textInputLayout2" />
+                app:layout_constraintTop_toBottomOf="@id/search_input_text" />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </FrameLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,48 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.SearchFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <data>
+
+    </data>
+
+    <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        tools:context=".ui.SearchFragment">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/textInputLayout2"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="match_parent">
 
-            <com.google.android.material.textfield.TextInputEditText
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/textInputLayout2"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/hint_text" />
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
 
-        </com.google.android.material.textfield.TextInputLayout>
+                <com.google.android.material.textfield.TextInputEditText
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/hint_text" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textInputLayout2" >
+            </com.google.android.material.textfield.TextInputLayout>
 
-        </androidx.recyclerview.widget.RecyclerView>
+            <androidx.recyclerview.widget.RecyclerView
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/textInputLayout2">
 
-        <TextView
-            android:id="@+id/textView2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/error_message"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/textInputLayout2" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</FrameLayout>
+            </androidx.recyclerview.widget.RecyclerView>
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/error_message"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/textInputLayout2" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -24,12 +24,12 @@
             android:text="@string/title"
             android:textSize="12sp"
             app:layout_constraintBottom_toBottomOf="@id/title_text"
-            app:layout_constraintEnd_toStartOf="@id/reload_text"
+            app:layout_constraintEnd_toStartOf="@id/reload_button"
             app:layout_constraintStart_toEndOf="@id/title_text"
             app:layout_constraintTop_toTopOf="parent" />
 
         <Button
-            android:id="@+id/reload_text"
+            android:id="@+id/reload_button"
             android:layout_width="wrap_content"
             android:layout_height="0dp"
             android:text="@string/load"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/searchFragment">
+
+    <fragment
+        android:id="@+id/searchFragment"
+        android:name="com.example.apipracticeapp.ui.SearchFragment"
+        android:label="fragment_search"
+        tools:layout="@layout/fragment_search" >
+        <action
+            android:id="@+id/action_searchFragment_to_resultFragment"
+            app:destination="@id/resultFragment"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim" />
+    </fragment>
+    <fragment
+        android:id="@+id/resultFragment"
+        android:name="com.example.apipracticeapp.ui.ResultFragment"
+        android:label="fragment_result"
+        tools:layout="@layout/fragment_result" />
+</navigation>


### PR DESCRIPTION
## 変更の概要

* NavGraphでのNavigationを追加した（引数なし、検索機能なし）
* [issue#4](https://github.com/takasshii/APIPracticeApp/issues/4)の問題が発生

## なぜこの変更をするのか

* 検索結果を表示できるようにするため

## やったこと

* [x] [コードラボ](https://developer.android.com/codelabs/android-navigation?index=..%2F..%2Findex#3)に沿ってNavgraphを作成、Fragmentから画面遷移
* [x] 改行ボタンを押した後に画面遷移が行われることを確認
* [x] [この記事](https://qiita.com/iTakahiro/items/b5fe2b186750c6e774e5)を参考にDatabindingを追加
* [x] AndroidManifestに必要事項を追加(https://qiita.com/konifar/items/92307f5dacec90e63d91)
* [ ] 検索ボタンの表示

## 変更内容
画面遷移の動作検証の様子
<img src="https://user-images.githubusercontent.com/83356340/187058986-91b12aa4-9ec7-4a40-9790-39366b90bd75.gif" width="200" >

## 影響範囲

* databindingにより、idから各部品を指定できるようになった

## どうやるのか

略

## 課題

* edittext周りの実装
* IME.SEARCHを指定しても、検索ボタンが表示されない → 仕方ないので改行で画面遷移を行うようにした点
* [issue#4](https://github.com/takasshii/APIPracticeApp/issues/4)の問題が発生

## 備考

* 検索周りが詰まったので、後からにしても良いかも