### PR TITLE
develop/addRepository

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.apipracticeapp">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -12,7 +14,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.APIPracticeApp"
-        tools:targetApi="31">
+        android:name=".GithubApplication"
+        tools:targetApi="31"
+        >
         <activity
             android:name=".ui.MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/apipracticeapp/GithubApplication.kt
+++ b/app/src/main/java/com/example/apipracticeapp/GithubApplication.kt
@@ -1,0 +1,7 @@
+package com.example.apipracticeapp
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class GithubApplication : Application()

--- a/app/src/main/java/com/example/apipracticeapp/data/GithubAPIRepository.kt
+++ b/app/src/main/java/com/example/apipracticeapp/data/GithubAPIRepository.kt
@@ -1,0 +1,18 @@
+package com.example.apipracticeapp.data
+
+// 結果を返すクラス
+sealed class APIResult<out R> {
+    // 成功した場合
+    data class Success<out T>(val data: T) : APIResult<T>()
+
+    // 失敗した場合
+    data class Error(val exception: Throwable) : APIResult<Nothing>()
+}
+
+interface GithubAPIRepository {
+    // APIResult型を返す
+    suspend fun getRepository(
+        header: String,
+        inputText: String
+    ): APIResult<JsonGithub?>
+}

--- a/app/src/main/java/com/example/apipracticeapp/data/GithubAPIRepositoryImpl.kt
+++ b/app/src/main/java/com/example/apipracticeapp/data/GithubAPIRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package com.example.apipracticeapp.data
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Header
+import retrofit2.http.Query
+import java.lang.Exception
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class GithubAPIRepositoryImpl @Inject constructor(
+    private val apiService: ApiService
+) : GithubAPIRepository {
+    override suspend fun getRepository(
+        header: String,
+        inputText: String
+    ): APIResult<JsonGithub?> =
+        withContext(Dispatchers.IO) {
+            try {
+                // 成功時
+                val apiResult =
+                    apiService.fetchRepositoryData(header, inputText)
+                // WeatherAPIResultに変形
+                APIResult.Success(
+                    data = apiResult.body()
+                )
+            } catch (e: Exception) {
+                // 失敗時
+                APIResult.Error(
+                    exception = e
+                )
+            }
+        }
+}
+
+interface ApiService {
+    @GET("search/repositories")
+    suspend fun fetchRepositoryData(
+        @Header("Accept") header: String,
+        @Query("q") inputText: String
+    ): Response<JsonGithub>
+}

--- a/app/src/main/java/com/example/apipracticeapp/data/JsonGithub.kt
+++ b/app/src/main/java/com/example/apipracticeapp/data/JsonGithub.kt
@@ -1,0 +1,33 @@
+package com.example.apipracticeapp.data
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class JsonGithub(
+    val items: List<Content>
+)
+
+@JsonClass(generateAdapter = true)
+data class Content(
+    val name: String,
+    @Json(name = "owner")
+    val owner: Owner,
+    @Json(name = "language")
+    val language: String?,
+    @Json(name = "stargazers_count")
+    val stargazersCount: Long,
+    @Json(name = "watchers_count")
+    val watchersCount: Long,
+    @Json(name = "forks_count")
+    val forksCount: Long,
+    @Json(name = "open_issues_count")
+    val openIssuesCount: Long,
+)
+
+@JsonClass(generateAdapter = true)
+data class Owner(
+    @Json(name = "avatar_url")
+    val avatarUrl: String
+)
+

--- a/app/src/main/java/com/example/apipracticeapp/di/GithubAPIModule.kt
+++ b/app/src/main/java/com/example/apipracticeapp/di/GithubAPIModule.kt
@@ -1,0 +1,53 @@
+package com.example.apipracticeapp.di
+
+import com.example.apipracticeapp.data.ApiService
+import com.example.apipracticeapp.data.GithubAPIRepository
+import com.example.apipracticeapp.data.GithubAPIRepositoryImpl
+import com.squareup.moshi.Moshi
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object GithubAPIModule {
+    @Provides
+    @Singleton
+    // Moshiのインスタンスを生成する
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    // Retrofitのインスタンスを生成する
+    fun provideRetrofit(
+        moshi: Moshi
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl("https://api.github.com")
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideGitHubService(retrofit: Retrofit): ApiService =
+        retrofit.create(ApiService::class.java)
+}
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class GithubAPIRepositoryModule {
+    @Singleton
+    @Binds
+    abstract fun bindWeatherAPIRepository(
+        impl: GithubAPIRepositoryImpl
+    ): GithubAPIRepository
+}

--- a/app/src/main/java/com/example/apipracticeapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/MainActivity.kt
@@ -3,7 +3,9 @@ package com.example.apipracticeapp.ui
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import com.example.apipracticeapp.R
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/apipracticeapp/ui/RankingFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/RankingFragment.kt
@@ -1,18 +1,24 @@
 package com.example.apipracticeapp.ui
 
 import android.os.Bundle
+import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.example.apipracticeapp.R
 import com.example.apipracticeapp.databinding.FragmentSearchBinding
+import dagger.hilt.android.AndroidEntryPoint
 
-class SearchFragment : Fragment() {
+@AndroidEntryPoint
+class RankingFragment : Fragment() {
     private var _binding: FragmentSearchBinding? = null
     private val binding get() = _binding!!
+
+    private val viewModel: RankingViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -20,14 +26,18 @@ class SearchFragment : Fragment() {
     ): View {
         _binding = FragmentSearchBinding.inflate(inflater, container, false)
 
-        binding.searchEditText.setOnEditorActionListener { textView, actionId, keyEvent ->
+        binding.searchEditText.setOnEditorActionListener { editText, actionId, keyEvent ->
             if (actionId == EditorInfo.IME_ACTION_SEARCH || actionId == EditorInfo.IME_NULL) {
+                editText.text.toString().let {
+                    // 入力された文字を代入
+                    viewModel.fetchAPI(it)
+                    Log.v("result", it)
+                }
                 navigationResultFragment()
                 return@setOnEditorActionListener true
             }
             return@setOnEditorActionListener false
         }
-
         return binding.root
     }
 

--- a/app/src/main/java/com/example/apipracticeapp/ui/RankingFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/RankingFragment.kt
@@ -28,7 +28,6 @@ class RankingFragment : Fragment() {
 
         binding.reloadButton.setOnClickListener {
             viewModel.fetchAPI()
-            Log.v("result", it)
         }
         return binding.root
     }

--- a/app/src/main/java/com/example/apipracticeapp/ui/RankingViewModel.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/RankingViewModel.kt
@@ -1,0 +1,59 @@
+package com.example.apipracticeapp.ui
+
+import android.util.Log
+import androidx.lifecycle.*
+import com.example.apipracticeapp.data.APIResult
+import com.example.apipracticeapp.data.GithubAPIRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RankingViewModel @Inject constructor(
+    private val githubAPIRepository: GithubAPIRepository
+) : ViewModel() {
+    private val _uiState =
+        MutableLiveData(UiState(repositories = null, proceeding = false))
+    val uiState: LiveData<UiState>
+        get() = _uiState
+
+    // APIを取得する関数
+    fun fetchAPI(inputText: String) {
+        _uiState.value = _uiState.value?.copy(proceeding = true)
+
+        // API取得(APIResultで結果をラップ)
+        viewModelScope.launch {
+            val result = githubAPIRepository.getRepository(
+                header = "application/vnd.github.v3+json", inputText = "stars"
+            )
+            Log.v("result", result.toString())
+            _uiState.value = when (result) {
+                is APIResult.Success -> {
+                    // liveDataに値をセット
+                    val newEvents = _uiState.value?.events?.plus(Event.Success)
+                    _uiState.value?.copy(
+                        events = newEvents ?: emptyList(),
+                        repositories = result.data
+                    )
+                }
+                // エラーが生じていた場合 -> エラー画像を表示
+                is APIResult.Error -> {
+                    val newEvents =
+                        _uiState.value?.events?.plus(Event.Error(result.exception.toString()))
+                    _uiState.value?.copy(events = newEvents ?: emptyList())
+                }
+            }
+            _uiState.value = _uiState.value?.copy(proceeding = false)
+        }
+    }
+
+    fun consumeEvent(event: Event) {
+        val newEvents = _uiState.value?.events?.filterNot { it == event }
+        _uiState.value = uiState.value?.copy(events = newEvents ?: emptyList())
+    }
+
+    fun nextPage() {
+        val newEvents = _uiState.value?.events?.plus(Event.NextPage)
+        _uiState.value = _uiState.value?.copy(events = newEvents ?: emptyList())
+    }
+}

--- a/app/src/main/java/com/example/apipracticeapp/ui/RankingViewModel.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/RankingViewModel.kt
@@ -18,7 +18,7 @@ class RankingViewModel @Inject constructor(
         get() = _uiState
 
     // APIを取得する関数
-    fun fetchAPI(inputText: String) {
+    fun fetchAPI() {
         _uiState.value = _uiState.value?.copy(proceeding = true)
 
         // API取得(APIResultで結果をラップ)

--- a/app/src/main/java/com/example/apipracticeapp/ui/ResultFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/ResultFragment.kt
@@ -6,7 +6,9 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.example.apipracticeapp.databinding.FragmentResultBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class ResultFragment : Fragment() {
     private var _binding: FragmentResultBinding? = null
     private val binding get() = _binding!!

--- a/app/src/main/java/com/example/apipracticeapp/ui/UIState.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/UIState.kt
@@ -1,0 +1,15 @@
+package com.example.apipracticeapp.ui
+
+import com.example.apipracticeapp.data.JsonGithub
+
+data class UiState(
+    val repositories: JsonGithub?,
+    val events: List<Event> = emptyList(),
+    val proceeding: Boolean
+)
+
+sealed interface Event {
+    object Success : Event
+    data class Error(val message: String) : Event
+    object NextPage: Event
+}

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -10,7 +10,7 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".ui.SearchFragment">
+        tools:context=".ui.RankingFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/searchFragment"
-        android:name="com.example.apipracticeapp.ui.SearchFragment"
+        android:name="com.example.apipracticeapp.ui.RankingFragment"
         android:label="fragment_search"
         tools:layout="@layout/fragment_search" >
         <action


### PR DESCRIPTION
## 変更の概要

* Hiltの導入
* Repository層の実装
* ViewModelを軽く実装して検証

## なぜこの変更をするのか

* ランキングを取得するためにAPIを叩く処理が必要になるから

## やったこと

* [x] Hiltを導入
* [x] インターネットのパーミッションを追加 
* [x] Moduleを作成してMoshiとRetrofitのインスタンスを作成
* [x] Moshiでパースするdata classの作成  
* [x] RepositoryとRepositoryImplを作成 
* [x] 検証用にViewModelを作成（かなり適当なので後で直す）

## 変更内容

* リクエスト 
```kotlin
val result = githubAPIRepository.getRepository(
    header = "application/vnd.github.v3+json", inputText = "stars"
)
```
* レスポンス
エラー時
```kotlin:Error
Error(exception=java.net.UnknownHostException: Unable to resolve host "api.github.com": No address associated with hostname)
```
成功したとき
```
2022-08-29 01:52:45.344 9179-9179/com.example.apipracticeapp V/result: Success(data=JsonGithub(items=[Content(name=starship, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/49654870?v=4), language=Rust, stargazersCount=28212, watchersCount=28212, forksCount=1183, openIssuesCount=440), Content(name=tacofancy, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/361410?v=4), language=CoffeeScript, stargazersCount=1257, watchersCount=1257, forksCount=455, openIssuesCount=13), Content(name=Starscream, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/905059?v=4), language=Swift, stargazersCount=7452, watchersCount=7452, forksCount=1048, openIssuesCount=154), Content(name=StarSpace, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/16943930?v=4), language=C++, stargazersCount=3778, watchersCount=3778, forksCount=531, openIssuesCount=54), Content(name=StarsAndClown, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/15868458?v=4), language=Python, stargazersCount=2039, watchersCount=2039, forksCount=162, openIssuesCount=7), Content(name=stars, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/25086656?v=4), language=R, stargazersCount=450, watchersCount=450, forksCount=83, openIssuesCount=21), Content(name=996.ICU, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/48942249?v=4), language=null, stargazersCount=263739, watchersCount=263739, forksCount=21517, openIssuesCount=16729), Content(name=pwc, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/2147644?v=4), language=null, stargazersCount=15406, watchersCount=15406, forksCount=2499, openIssuesCount=24), Content(name=go-web-framework-stars, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/6178510?v=4), language=Go, stargazersCount=2677, watchersCount=2677, forksCount=217, openIssuesCount=15), Content(name=pueue, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/3322822?v=4), language=Rust, stargazersCount=3062, watchersCount=3062, forksCount=82, openIssuesCount=8), Content(name=astral, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/11477125?v=4), language=PHP, stargazersCount=2889, watchersCount=2889, forksCount=137, openIssuesCount=41), Content(name=layout_stars, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/28379899?v=4), language=JavaScript, stargazersCount=0, watchersCount=0, forksCount=1579, openIssuesCount=1648), Content(name=deoplete.nvim, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/41495?v=4), language=Python, stargazersCount=5818, watchersCount=5818, forksCount=309, openIssuesCount=1), Content(name=Recent-Stars-2022, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/18531182?v=4), language=null, stargazersCount=610, watchersCount=610, forksCount=118, openIssuesCount=1), Content(name=adamalston, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/18297826?v=4), language=null, stargazersCount=110, watchersCount=110, forksCount=385, openIssuesCount=0), Content(name=DeepLearningStars, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/901975?v=4), language=Python, stargazersCount=381, watchersCount=381, forksCount=113, openIssuesCount=2), Content(name=react-stars, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/2053878?v=4), language=JavaScript, stargazersCount=195, watchersCount=195, forksCount=80, openIssuesCount=43), Content(name=starcharts, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/245435?v=4), language=Go, stargazersCount=891, watchersCount=891, forksCount=97, openIssuesCount=4), Content(name=Crypto-Signal, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/36821914?v=4), language=Python, stargazersCount=4116, watchersCount=4116, forksCount=1145, openIssuesCount=59), Content(name=stargazers, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/6147149?v=4), language=Go, stargazersCount=367, watchersCount=367, forksCount=40, openIssuesCount=11), Content(name=awesome-stars, owner=Owner(avatarUrl=https://avatars.githubusercontent.com/u/7894483?v=4), la
```

## 影響範囲

* アーキテクチャ根本をいじっているので、早めにマージすること

## どうやるのか

略

## 課題

* ViewModelは検証用のため、後から新しいプルリクを立てて検証します。
↑このプルリクに含めなくてよかったかも

* このプルリクに色々まとめすぎてブラックボックスになっているので、Hiltで切り出すべきでした
## 備考

* その他に伝えたいこと