### PR TITLE
develop/addDialog

### DIFF
--- a/app/src/main/java/com/example/apipracticeapp/ui/CustomAdapter.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/CustomAdapter.kt
@@ -45,7 +45,7 @@ class CustomAdapter(
         val item = getItem(position)
         setRepositoryName(holder, item)
 
-        // ここでランキングに値をセット
+        // タップ処理を定義
         holder.itemView.setOnClickListener {
             itemClickListener.itemClick(item)
         }

--- a/app/src/main/java/com/example/apipracticeapp/ui/ErrorDialogFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/ErrorDialogFragment.kt
@@ -1,0 +1,29 @@
+package com.example.apipracticeapp.ui
+
+import android.app.AlertDialog
+import android.app.Dialog
+import androidx.fragment.app.DialogFragment
+import com.example.apipracticeapp.R
+
+class ErrorDialogFragment(
+    private val onDialogPositiveClick: NoticeDialogListener
+) : DialogFragment() {
+
+    interface NoticeDialogListener {
+        fun positiveClick()
+    }
+
+    override fun onCreateDialog(savedInstanceState: android.os.Bundle?): Dialog {
+        return AlertDialog.Builder(requireActivity())
+            .setTitle(getString(R.string.error_dialog_title))
+            .setMessage(getString(R.string.error_dialog_message))
+            .setPositiveButton(getString(R.string.error_dialog_positive_button)) { _, _ ->
+                // 再読み込みを行う
+                onDialogPositiveClick.positiveClick()
+            }
+            .setNegativeButton(getString(R.string.error_dialog_negative_button)) { _, _ ->
+                // 何もしない
+            }
+            .create()
+    }
+}

--- a/app/src/main/java/com/example/apipracticeapp/ui/RankingFragment.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/RankingFragment.kt
@@ -66,7 +66,8 @@ class RankingFragment : Fragment() {
                         viewModel.consumeEvent(event)
                     }
                     is Event.Error -> {
-                        // ここでダイアログの表示を行う（未実装）
+                        // ここでダイアログの表示を行う
+                        showNoticeDialog()
                         // イベントを消費
                         viewModel.consumeEvent(event)
                     }
@@ -89,6 +90,15 @@ class RankingFragment : Fragment() {
         super.onDestroyView()
         //bindingの解放
         _binding = null
+    }
+
+    private fun showNoticeDialog() {
+        val dialog = ErrorDialogFragment(object : ErrorDialogFragment.NoticeDialogListener {
+            override fun positiveClick() {
+                viewModel.fetchAPI()
+            }
+        })
+        dialog.show(childFragmentManager, "APIError")
     }
 
     private fun navigationResultFragment() {

--- a/app/src/main/java/com/example/apipracticeapp/ui/RankingViewModel.kt
+++ b/app/src/main/java/com/example/apipracticeapp/ui/RankingViewModel.kt
@@ -12,6 +12,7 @@ import javax.inject.Inject
 class RankingViewModel @Inject constructor(
     private val githubAPIRepository: GithubAPIRepository
 ) : ViewModel() {
+    // 状態変数を管理するLiveData
     private val _uiState =
         MutableLiveData(UiState(repositories = null, proceeding = false))
     val uiState: LiveData<UiState>
@@ -19,39 +20,50 @@ class RankingViewModel @Inject constructor(
 
     // APIを取得する関数
     fun fetchAPI() {
+        // ローディング開始
         _uiState.value = _uiState.value?.copy(proceeding = true)
 
         // API取得(APIResultで結果をラップ)
         viewModelScope.launch {
+            // ランキングを取得する
+            // headerでjsonを指定, inputTextでランキングを指定
             val result = githubAPIRepository.getRepository(
                 header = "application/vnd.github.v3+json", inputText = "stars"
             )
-            Log.v("result", result.toString())
+
+            // レスポンスに応じてLiveDataに値を格納
             _uiState.value = when (result) {
                 is APIResult.Success -> {
-                    // liveDataに値をセット
+                    // ViewModelイベント発行
                     val newEvents = _uiState.value?.events?.plus(Event.Success)
+                    //　値をセット
                     _uiState.value?.copy(
                         events = newEvents ?: emptyList(),
                         repositories = result.data
                     )
                 }
-                // エラーが生じていた場合 -> エラー画像を表示
+                // エラーが生じていた場合 -> エラーダイアログを表示
                 is APIResult.Error -> {
+                    // ViewModelイベント発行
                     val newEvents =
                         _uiState.value?.events?.plus(Event.Error(result.exception.toString()))
+                    // 値をセット
                     _uiState.value?.copy(events = newEvents ?: emptyList())
                 }
             }
+
+            // ローディングを終了
             _uiState.value = _uiState.value?.copy(proceeding = false)
         }
     }
 
+    // イベントを消費する関数
     fun consumeEvent(event: Event) {
         val newEvents = _uiState.value?.events?.filterNot { it == event }
         _uiState.value = uiState.value?.copy(events = newEvents ?: emptyList())
     }
 
+    // 次のページに進むEventを発行する関数
     fun nextPage() {
         val newEvents = _uiState.value?.events?.plus(Event.NextPage)
         _uiState.value = _uiState.value?.copy(events = newEvents ?: emptyList())

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -4,7 +4,11 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
+        <import type="android.view.View" />
 
+        <variable
+            name="viewModel"
+            type="com.example.apipracticeapp.ui.RankingViewModel" />
     </data>
 
     <FrameLayout
@@ -63,16 +67,6 @@
 
             </androidx.recyclerview.widget.RecyclerView>
 
-        <TextView
-            android:id="@+id/textView2"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/error_message"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/title_text" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,8 @@
     <string name="error_message">エラーが発生しました。やり直してください。</string>
     <string name="title">スター数ランキング</string>
     <string name="load">更新</string>
+    <string name="error_dialog_title">エラーが発生しました</string>
+    <string name="error_dialog_message">インターネット接続を確認して、やり直してください。</string>
+    <string name="error_dialog_positive_button">やり直す</string>
+    <string name="error_dialog_negative_button">閉じる</string>
 </resources>


### PR DESCRIPTION
## 変更の概要

* エラー時にダイアログを表示するようにした
* エラー時にボタンを押すことで再リロードが可能になった
* [issue](https://github.com/takasshii/APIPracticeApp/issues/10)の解決

## なぜこの変更をするのか

* エラー通知を行うため

## やったこと

* [x] FragmentDialogを追加
* [x] interfaceを定義し、Fragment内でoverrideすることで、再リロードを呼び出した

## 変更内容

<img src = "https://user-images.githubusercontent.com/83356340/187154104-a8774b71-f451-48c7-a125-91d7413ad470.gif" width = "200">


## 影響範囲

略

## どうやるのか

* エラーを起こした状態（オフラインにするなど）で更新ボタンを押すとダイアログが表示される
* ダイアログ内で閉じるボタンを押すと、ダイアログが閉じる
* やり直すボタンを押すと、fetchAPI()が呼び出される

## 課題

* [公式ドキュメント](https://developer.android.com/guide/topics/ui/dialogs?hl=ja#ShowingADialog)の方法だとうまくいかなかったため、以下のように変更した。この実装に不安がある。
1. onAttachの関数を削除した。onAttachはActivityなのでFragmentからは呼び出されないからと考えられる。
2. onAttachでリスナーをインスタンス化していたため、別の方法でリスナーを呼び出すようにした
```kotlin
class ErrorDialogFragment(
    private val onDialogPositiveClick: NoticeDialogListener
) : DialogFragment() {

    interface NoticeDialogListener {
        fun positiveClick()
    }
```
```kotlin
 private fun showNoticeDialog() {
        val dialog = ErrorDialogFragment(object : ErrorDialogFragment.NoticeDialogListener {
            override fun positiveClick() {
                viewModel.fetchAPI()
            }
        })
        dialog.show(childFragmentManager, "APIError")
    }
```

## 備考
