### PR TITLE
[add] proceedingに応じてローディングする画面を追加

### DIFF
--- a/app/src/main/res/layout/fragment_ranking.xml
+++ b/app/src/main/res/layout/fragment_ranking.xml
@@ -68,5 +68,20 @@
             </androidx.recyclerview.widget.RecyclerView>
 
         </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <View
+            android:id="@+id/view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:alpha="@{viewModel.uiState.proceeding ? 0.5F : 0F}"
+            android:background="#000000" />
+
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="@{viewModel.uiState.proceeding ? View.VISIBLE : View.INVISIBLE}" />
 </FrameLayout>
 </layout>


### PR DESCRIPTION
## 変更の概要

* loading画面を追加
* Issue #22 

## なぜこの変更をするのか

* 変数だけ用意して実装をするのを忘れていたため

## やったこと

* [x] xmlファイルにProgressBarとViewを追加
* [x] progressに応じて背景を黒くし、ローディングのサークルを表示 

## 変更内容

* UIの変更ならスクリーンショット

<!-- 5MB以下のGIF画像でお願いします。 -->
|before|after|
|---|---|
|略|<img src = "https://user-images.githubusercontent.com/83356340/187461509-f1c168be-1440-4006-b1ed-129d046c5e37.gif" width = "200">|


* APIの変更ならリクエストとレスポンス

## 影響範囲

* loading中を確認することができる

## どうやるのか

* 更新ボタンを押せばloading画面が出ます

## 課題

なし

## 備考

* xml内に記述する量を増やせばもうちょいスッキリしそうなので余力があったらやりましょう！
